### PR TITLE
[ci] update helm orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 orbs:
   docker: circleci/docker@1.0.0
   go: circleci/go@1.1.0
-  helm: circleci/helm@0.2.3
+  helm: circleci/helm@1.2.0
 
 commands:
 


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

Old helm orb was using a deprecated repo to get charts. Update the orb so helm-lint job passes again.